### PR TITLE
Improvements for the `DiffCalculation` plugin

### DIFF
--- a/aiida_diff/calculations.py
+++ b/aiida_diff/calculations.py
@@ -3,13 +3,14 @@ Calculations provided by aiida_diff.
 
 Register calculations via the "aiida.calculations" entry point in setup.json.
 """
-
 from __future__ import absolute_import
+
+import six
+
+from aiida.common import datastructures
 from aiida.engine import CalcJob
 from aiida.orm import SinglefileData
-from aiida.common.datastructures import (CalcInfo, CodeInfo)
 from aiida.plugins import DataFactory
-import six
 
 DiffParameters = DataFactory('diff')
 
@@ -17,77 +18,45 @@ DiffParameters = DataFactory('diff')
 class DiffCalculation(CalcJob):
     """
     AiiDA calculation plugin wrapping the diff executable.
-    
+
     Simple AiiDA plugin wrapper for 'diffing' two files.
     """
 
-    _OUTPUT_FILE_NAME = 'patch.diff'
-
-    # diff.product entry point defined in setup.json
-    _DEFAULT_PARSER = 'diff'
-
     @classmethod
     def define(cls, spec):
-        """
-        Define inputs of calculation.
-        
-        """
+        """Define inputs and outputs of the calculation."""
+        # yapf: disable
         super(DiffCalculation, cls).define(spec)
-
-        spec.input('metadata.options.parser_name',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_PARSER)
-        spec.input('metadata.options.output_filename',
-                   valid_type=six.string_types,
-                   default=cls._OUTPUT_FILE_NAME)
-
-        spec.input('metadata.options.parser_name',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_PARSER)
-
-        spec.input('parameters',
-                   valid_type=DiffParameters,
-                   help='Command line parameters for diff')
-        spec.input('file1',
-                   valid_type=SinglefileData,
-                   help='First file to be compared.')
-        spec.input('file2',
-                   valid_type=SinglefileData,
-                   help='Second file to be compared.')
-
-        spec.output('diff',
-                    valid_type=SinglefileData,
-                    help='diff between file1 and file2.')
+        spec.input('metadata.options.parser_name', valid_type=six.string_types, default='diff')
+        spec.input('metadata.options.output_filename', valid_type=six.string_types, default='patch.diff')
+        spec.input('parameters', valid_type=DiffParameters, help='Command line parameters for diff')
+        spec.input('file1', valid_type=SinglefileData, help='First file to be compared.')
+        spec.input('file2', valid_type=SinglefileData, help='Second file to be compared.')
+        spec.output('diff', valid_type=SinglefileData, help='diff between file1 and file2.')
 
     def prepare_for_submission(self, folder):
         """
         Create input files.
 
-        :param folder: an `aiida.common.folders.Folder` where the plugin should temporarily place all files needed by the calculation.
+        :param folder: an `aiida.common.folders.Folder` where the plugin should temporarily place all files needed by
+            the calculation.
         :return: `aiida.common.datastructures.CalcInfo` instance
-
         """
-        # Prepare CalcInfo to be returned to aiida
-        calcinfo = CalcInfo()
-        calcinfo.uuid = self.uuid
-
-        calcinfo.local_copy_list = [
-            (self.inputs.file1.uuid, self.inputs.file1.filename,
-             self.inputs.file1.filename),
-            (self.inputs.file2.uuid, self.inputs.file2.filename,
-             self.inputs.file2.filename),
-        ]
-        calcinfo.remote_copy_list = []
-        calcinfo.retrieve_list = [self._OUTPUT_FILE_NAME]
-
-        codeinfo = CodeInfo()
+        codeinfo = datastructures.CodeInfo()
         codeinfo.cmdline_params = self.inputs.parameters.cmdline_params(
             file1_name=self.inputs.file1.filename,
             file2_name=self.inputs.file2.filename)
         codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.stdout_name = self.metadata.options.output_filename
         codeinfo.withmpi = False
-        codeinfo.stdout_name = self._OUTPUT_FILE_NAME
 
+        # Prepare a `CalcInfo` to be returned to the engine
+        calcinfo = datastructures.CalcInfo()
         calcinfo.codes_info = [codeinfo]
+        calcinfo.local_copy_list = [
+            (self.inputs.file1.uuid, self.inputs.file1.filename, self.inputs.file1.filename),
+            (self.inputs.file2.uuid, self.inputs.file2.filename, self.inputs.file2.filename),
+        ]
+        calcinfo.retrieve_list = [self.metadata.options.output_filename]
 
         return calcinfo

--- a/aiida_diff/parsers.py
+++ b/aiida_diff/parsers.py
@@ -58,7 +58,7 @@ class DiffParser(Parser):
         # Use something like this to loop over multiple output files
         for fname, link in zip(output_files, output_links):
 
-            with output_folder.open(fname) as handle:
+            with output_folder.open(fname, 'rb') as handle:
                 node = SinglefileData(file=handle)
             self.out(link, node)
 

--- a/setup.json
+++ b/setup.json
@@ -31,7 +31,7 @@
     "setup_requires": ["reentry"],
     "reentry_register": true,
     "install_requires": [
-        "aiida-core>=1.0.0b1,<2.0.0",
+        "aiida-core>=1.0.0b3,<2.0.0",
         "six",
         "voluptuous"
     ],


### PR DESCRIPTION
Removes duplicated input port definitions and gets rid of class
variables used to set the defaults for metadata inputs. Since these are
set on the process spec, they should be retrieved from the process spec
or the actual inputs, depending on the use case. For example in the
`prepare_for_submission` the actual values passed to the process should
be used, otherwise making them configurable options does not make sense
if we are always going to override them with the class variable.