### PR TITLE
simplify parser a bit further

### DIFF
--- a/aiida_diff/calculations.py
+++ b/aiida_diff/calculations.py
@@ -35,6 +35,9 @@ class DiffCalculation(CalcJob):
         spec.input('file2', valid_type=SinglefileData, help='Second file to be compared.')
         spec.output('diff', valid_type=SinglefileData, help='diff between file1 and file2.')
 
+        spec.exit_code(100, 'ERROR_MISSING_OUTPUT_FILES', message='Calculation did not produce all expected output files.')
+
+
     def prepare_for_submission(self, folder):
         """
         Create input files.
@@ -49,7 +52,7 @@ class DiffCalculation(CalcJob):
             file2_name=self.inputs.file2.filename)
         codeinfo.code_uuid = self.inputs.code.uuid
         codeinfo.stdout_name = self.metadata.options.output_filename
-        codeinfo.withmpi = False
+        codeinfo.withmpi = self.inputs.metadata.options.withmpi
 
         # Prepare a `CalcInfo` to be returned to the engine
         calcinfo = datastructures.CalcInfo()

--- a/aiida_diff/data/__init__.py
+++ b/aiida_diff/data/__init__.py
@@ -74,7 +74,8 @@ class DiffParameters(Dict):
 
         pm_dict = self.get_dict()
         for k in pm_dict.keys():
-            parameters += ['--' + k]
+            if pm_dict[k]:
+                parameters += ['--' + k]
 
         parameters += [file1_name, file2_name]
 

--- a/aiida_diff/parsers.py
+++ b/aiida_diff/parsers.py
@@ -6,11 +6,8 @@ Register parsers via the "aiida.parsers" entry point in setup.json.
 """
 from __future__ import absolute_import
 
-from six.moves import zip
-
 from aiida.engine import ExitCode
 from aiida.parsers.parser import Parser
-from aiida.common import exceptions
 from aiida.plugins import CalculationFactory
 
 DiffCalculation = CalculationFactory('diff')
@@ -30,6 +27,7 @@ class DiffParser(Parser):
         :param node: ProcessNode of calculation
         :param type node: :class:`aiida.orm.ProcessNode`
         """
+        from aiida.common import exceptions
         super(DiffParser, self).__init__(node)
         if not issubclass(node.process_class, DiffCalculation):
             raise exceptions.ParsingError("Can only parse DiffCalculation")
@@ -42,29 +40,19 @@ class DiffParser(Parser):
         """
         from aiida.orm import SinglefileData
 
-        # Check that the retrieved folder is there
-        try:
-            output_folder = self.retrieved
-        except exceptions.NotExistent:
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
+        output_filename = self.node.get_option('output_filename')
 
-        # Check the folder content is as expected
-        list_of_files = output_folder.list_object_names()
-        output_files = [self.node.get_option('output_filename')]
-        output_links = ['diff']
-        # Note: set(A) <= set(B) checks whether A is a subset
-        if set(output_files) <= set(list_of_files):
-            pass
-        else:
-            self.logger.error(
-                "Not all expected output files {} were found".format(
-                    output_files))
+        # Check that folder content is as expected
+        files_retrieved = self.retrieved.list_object_names()
+        files_expected = [output_filename]
+        # Note: set(A) <= set(B) checks whether A is a subset of B
+        if not set(files_expected) <= set(files_retrieved):
+            self.logger.error("Found files '{}', expected to find '{}'".format(
+                files_retrieved, files_expected))
 
-        # Use something like this to loop over multiple output files
-        for fname, link in zip(output_files, output_links):
-
-            with output_folder.open(fname, 'rb') as handle:
-                node = SinglefileData(file=handle)
-            self.out(link, node)
+        # add output file
+        with self.retrieved.open(output_filename, 'rb') as handle:
+            output_node = SinglefileData(file=handle)
+        self.out('diff', output_node)
 
         return ExitCode(0)

--- a/aiida_diff/parsers.py
+++ b/aiida_diff/parsers.py
@@ -49,8 +49,10 @@ class DiffParser(Parser):
         if not set(files_expected) <= set(files_retrieved):
             self.logger.error("Found files '{}', expected to find '{}'".format(
                 files_retrieved, files_expected))
+            return self.exit_codes.ERROR_MISSING_OUTPUT_FILES
 
         # add output file
+        self.logger.info("Parsing '{}'".format(output_filename))
         with self.retrieved.open(output_filename, 'rb') as handle:
             output_node = SinglefileData(file=handle)
         self.out('diff', output_node)


### PR DESCRIPTION
 * remove boilerplate check for retrieved folder
 * remove loop over output files
   (not necessary here, complicates logic)