### PR TITLE
🐛 FIX: Docs build on RTD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[docs]
-        reentry scan -r aiida
     - name: Build docs
       run: cd docs && make
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,7 @@ import aiida_diff
 
 # -- AiiDA-related setup --------------------------------------------------
 
+# ensure all entry point plugins are lodaed
 manager.scan()
 
 # Load the dummy profile even if we are running locally, this way the documentation will succeed even if the current

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ import aiida_diff
 
 # -- AiiDA-related setup --------------------------------------------------
 
-# ensure all entry point plugins are lodaed
+# ensure all entry-point plugins are lodaed
 manager.scan()
 
 # Load the dummy profile even if we are running locally, this way the documentation will succeed even if the current

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,11 +14,15 @@ import os
 import sys
 import time
 
+from reentry import manager
+
 from aiida.manage.configuration import load_documentation_profile
 
 import aiida_diff
 
 # -- AiiDA-related setup --------------------------------------------------
+
+manager.scan()
 
 # Load the dummy profile even if we are running locally, this way the documentation will succeed even if the current
 # default profile of the AiiDA installation does not use a Django backend.


### PR DESCRIPTION
RTD does not call `reentry scan`,
so we call it programatically in the conf.py